### PR TITLE
Refactor js modules and clean html

### DIFF
--- a/disc-03.html
+++ b/disc-03.html
@@ -1,8 +1,7 @@
 <div class="close-btn"></div>
 <div class="disc-cover">
-	<div><img src="img/discography/disc-02.jpg" /></div>
+  <div><img src="img/discography/disc-02.jpg" /></div>
 </div>
 <div>COMING SOON</div>
 
-</div>
 <div class="clear"></div>

--- a/index.html
+++ b/index.html
@@ -223,7 +223,6 @@
                 title="YouTube video player" frameborder="0" allowfullscreen
                 style="position:absolute;top:0;left:0;width:100%;height:100%;"></iframe>
         </div>
-        </div>
     </section>
     <div class="clear"></div>
 

--- a/js/discography.js
+++ b/js/discography.js
@@ -1,38 +1,48 @@
 /* Dynamic Window Ajax Content */
 "use strict";
 
-var $actual= null;
-var obert=false;
-$(".open-disc").click(function() {
-		obre($(this).attr('id'));
-		$actual=$(this);
+var $actual = null;
+var obert = false;
+$(".open-disc").click(function () {
+  obre($(this).attr("id"));
+  $actual = $(this);
 });
-		
-function obre(quin){
-$.ajax({
-	url: quin,
-	success: function(data) {					
-		$('.project-content').html(data);
-		$(".project-content").hide(0)
-		$('.project-window').hide(0)	
-		tanca();
-		$("html, body").animate({ scrollTop: $('#project-show').offset().top - (200) }, 300, function(){
-			$('.project-window').show(0);
-			$('.project-window').css('height','0');
-			$('.project-window').animate({height:550}, 500,function(){
-				$('.project-window').css('height',550); /*$('.project-window').css('height','auto');*/
-				$(".project-content").fadeIn("slow");
-			});				
-		});
-	}
-});
+
+function obre(quin) {
+  $.ajax({
+    url: quin,
+    success: function (data) {
+      $(".project-content").html(data);
+      $(".project-content").hide(0);
+      $(".project-window").hide(0);
+      tanca();
+      $("html, body").animate(
+        { scrollTop: $("#project-show").offset().top - 200 },
+        300,
+        function () {
+          $(".project-window").show(0);
+          $(".project-window").css("height", "0");
+          $(".project-window").animate({ height: 550 }, 500, function () {
+            $(".project-window").css(
+              "height",
+              550,
+            ); /*$('.project-window').css('height','auto');*/
+            $(".project-content").fadeIn("slow");
+          });
+        },
+      );
+    },
+  });
 }
 
-function tanca(){
-	$(".close-btn").click(function() {
-		$(".project-window").slideUp("slow");
-		$(".project-content").fadeOut("slow");
-		$("html, body").animate({ scrollTop: $('#anchor02').offset().top -(50) }, 1000);
-		obert=false;
-	});
+function tanca() {
+  $(".close-btn").click(function () {
+    $(".project-window").slideUp("slow");
+    $(".project-content").fadeOut("slow");
+    $("html, body").animate(
+      { scrollTop: $("#anchor02").offset().top - 50 },
+      1000,
+    );
+    obert = false;
+  });
 }

--- a/js/news.js
+++ b/js/news.js
@@ -1,97 +1,105 @@
 /* Dynamic Window Ajax Content */
 "use strict";
 
-var $actual2= null;
-var obert2=false;
-$(".last-news").click(function() {
-		obre2($(this).attr('id'));
-		$actual2=$(this);
+var $actual2 = null;
+var obert2 = false;
+$(".last-news").click(function () {
+  obre2($(this).attr("id"));
+  $actual2 = $(this);
 });
-		
-function obre2(quin2){
-	$.ajax({
-		url: quin2,
-		success: function(data) {					
-			$('.news-content').html(data);
-			$(".news-content").hide(0)
-			$('.news-window').hide(0)	
-			tanca2();
-			canvia2();	
-			$("html, body").animate({ scrollTop: $('#news-show').offset().top - (200) }, 500, function(){
-				$('.news-window').show(0);
-				$('.news-window').css('height','0');
-				$('.news-window').animate({height:760}, 1000,function(){
-					$('.news-window').css('height','760');
-					$(".news-content").fadeIn("slow");
-				});				
-			});
-		}
-	});
-}
-/**/
-function canvi2(quin2){
-	var obert2=true;
-	$.ajax({
-		url: quin2,
-		success: function(data) {					
-			$('.news-content').html(data);
-			tanca2();
-			canvia2();
-			$("html, body").animate({ scrollTop: $('#news-show').offset().top - (200) }, 500, function(){
-				$('.news-window').show(0);
-				$('.news-window').animate({height:760}, 1000,function(){
-					$('.news-window').css('height','760');
-					$(".news-content").fadeIn("slow");
-				});				
-			});
-		}
-	});
-}
-/**/
-function tanca2(){
-	$(".close2-btn").click(function() {
-		$(".news-window").slideUp("slow");
-		$(".news-content").fadeOut("slow");
-		$("html, body").animate({ scrollTop: $('#anchor01').offset().top }, 1000);
-		obert2=false;
-	});
-}
-function seguent(){
-	if($actual2.next().hasClass('end')){
-		$(".news-content").fadeOut("slow");
-		$actual2=$($('.start').next());
-	}else{
-		$(".news-content").fadeOut("slow");
-		$actual2=$($actual2.next());
-	}
-	if($actual2.hasClass('isotope-hidden')){
-		seguent();
-	}else{
-		$(".news-content").fadeOut("slow");
-		canvi2($actual2.attr('id'));
-	}
-}
-function enrera(){
-	if($actual2.prev().hasClass('start')){
-		$(".news-content").fadeOut("slow");
-		$actual2=$($('.end').prev());
-	}else{
-		$(".news-content").fadeOut("slow");
-		$actual2=$($actual2.prev());
-	}
 
-	if($actual2.hasClass('isotope-hidden')){
-		enrera();
-	}else{
-		$(".news-content").fadeOut("slow");
-		canvi2($actual2.attr('id'));
-	}
+function obre2(quin2) {
+  $.ajax({
+    url: quin2,
+    success: function (data) {
+      $(".news-content").html(data);
+      $(".news-content").hide(0);
+      $(".news-window").hide(0);
+      tanca2();
+      canvia2();
+      $("html, body").animate(
+        { scrollTop: $("#news-show").offset().top - 200 },
+        500,
+        function () {
+          $(".news-window").show(0);
+          $(".news-window").css("height", "0");
+          $(".news-window").animate({ height: 760 }, 1000, function () {
+            $(".news-window").css("height", "760");
+            $(".news-content").fadeIn("slow");
+          });
+        },
+      );
+    },
+  });
 }
-function canvia2(){
-	$('.news-next').click(function() {
-		seguent();
-	});
-	$('.news-prev').click(function() {
-		enrera();
-	});
+/**/
+function canvi2(quin2) {
+  var obert2 = true;
+  $.ajax({
+    url: quin2,
+    success: function (data) {
+      $(".news-content").html(data);
+      tanca2();
+      canvia2();
+      $("html, body").animate(
+        { scrollTop: $("#news-show").offset().top - 200 },
+        500,
+        function () {
+          $(".news-window").show(0);
+          $(".news-window").animate({ height: 760 }, 1000, function () {
+            $(".news-window").css("height", "760");
+            $(".news-content").fadeIn("slow");
+          });
+        },
+      );
+    },
+  });
+}
+/**/
+function tanca2() {
+  $(".close2-btn").click(function () {
+    $(".news-window").slideUp("slow");
+    $(".news-content").fadeOut("slow");
+    $("html, body").animate({ scrollTop: $("#anchor01").offset().top }, 1000);
+    obert2 = false;
+  });
+}
+function seguent() {
+  if ($actual2.next().hasClass("end")) {
+    $(".news-content").fadeOut("slow");
+    $actual2 = $($(".start").next());
+  } else {
+    $(".news-content").fadeOut("slow");
+    $actual2 = $($actual2.next());
+  }
+  if ($actual2.hasClass("isotope-hidden")) {
+    seguent();
+  } else {
+    $(".news-content").fadeOut("slow");
+    canvi2($actual2.attr("id"));
+  }
+}
+function enrera() {
+  if ($actual2.prev().hasClass("start")) {
+    $(".news-content").fadeOut("slow");
+    $actual2 = $($(".end").prev());
+  } else {
+    $(".news-content").fadeOut("slow");
+    $actual2 = $($actual2.prev());
+  }
+
+  if ($actual2.hasClass("isotope-hidden")) {
+    enrera();
+  } else {
+    $(".news-content").fadeOut("slow");
+    canvi2($actual2.attr("id"));
+  }
+}
+function canvia2() {
+  $(".news-next").click(function () {
+    seguent();
+  });
+  $(".news-prev").click(function () {
+    enrera();
+  });
 }


### PR DESCRIPTION
## Summary
- refactor `discography.js` and `news.js` for readability
- remove stray closing tags in `index.html` and `disc-03.html`
- prettify custom JavaScript

## Testing
- `prettier -w js/discography.js js/news.js disc-03.html`

------
https://chatgpt.com/codex/tasks/task_e_684134c9fc388324b09f10f93f44be7d