### PR TITLE
Convert two gallery items to YouTube videos

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,7 +284,7 @@
                     <div class="ch-grid element">
                         <img class="ch-item" src="img/gallery/thumb-03.jpg" alt="Owen Hamlin gallery thumbnail 3"
                             loading="lazy" />
-                        <a href="https://www.youtube.com/watch?v=kZKUklfoAIA" rel="" class="fancybox-media"
+                        <a href="https://www.youtube.com/watch?v=CWYlma3sNMQ" rel="" class="fancybox-media"
                             role="button" aria-label="Owen Hamlin Gallery Video">
                             <div>
                                 <span class="p-category video"></span>
@@ -317,11 +317,10 @@
                     <div class="ch-grid element">
                         <img class="ch-item" src="img/gallery/thumb-06.jpg" alt="Owen Hamlin gallery thumbnail 6"
                             loading="lazy" />
-                        <a class="fancybox img-lightbox" rel=""
-                            href="img/owen/5741DE3C-8715-4F70-827C-24DA81A5D33B.jpeg" role="button"
-                            aria-label="Owen Hamlin Gallery Image">
+                        <a href="https://www.youtube.com/watch?v=Uo-bCnUP_wU" rel="" class="fancybox-media"
+                            role="button" aria-label="Owen Hamlin Gallery Video">
                             <div>
-                                <span class="p-category photo"></span>
+                                <span class="p-category video"></span>
                             </div>
                         </a>
                     </div>


### PR DESCRIPTION
Update index.html to replace two gallery entries with YouTube video links. Thumbnail 3's link was changed to https://www.youtube.com/watch?v=CWYlma3sNMQ, and thumbnail 6 was converted from an image lightbox (removed img/owen JPEG href and img-lightbox class) to a fancybox-media YouTube link (https://www.youtube.com/watch?v=Uo-bCnUP_wU). Also update the category marker from photo to video for the second item so both display as videos in the gallery.